### PR TITLE
Added application/vnd.api.v2+json header required by API

### DIFF
--- a/src/Yclients/YclientsRequest.php
+++ b/src/Yclients/YclientsRequest.php
@@ -103,7 +103,7 @@ trait YclientsRequest
      */
     public function request($url, $parameters = [], $method = 'GET', $auth = true)
     {
-        $headers = [ 'Content-Type: application/json' ];
+        $headers = [ 'Content-Type: application/json', 'Accept: application/vnd.api.v2+json' ];
 
         if ($auth) {
             if (!$this->tokenPartner) {


### PR DESCRIPTION
YClients API strictly requires Accept: application/vnd.api.v2+json header to function.
Added it to YClientsRequest.

Closes #1 